### PR TITLE
Check for cohort existence before create

### DIFF
--- a/app/models/census_cohort.rb
+++ b/app/models/census_cohort.rb
@@ -9,7 +9,8 @@ class CensusCohort
       nil
     else
       formatted = cohort_info.first.except("start_date", "status")
-      cohort = TuringCohort.create(formatted)
+      formatted["census_id"] = formatted.delete("id")
+      cohort = TuringCohort.where(census_id: formatted["census_id"]).first_or_create(formatted)
       CensusUser.create_from_census_cohort(cohort)
 
       cohort

--- a/app/services/census_service.rb
+++ b/app/services/census_service.rb
@@ -19,7 +19,7 @@ class CensusService
     response = conn.get do |req|
       req.url '/api/v1/users/by_cohort'
       req.params['access_token'] = token
-      req.params['cohort_id'] = cohort.id
+      req.params['cohort_id'] = cohort.census_id
     end
     JSON.parse(response.body)
   end


### PR DESCRIPTION
* Match `census_id` in `CensusCohort::create_from_name` so that it moves the id from Census to the `census_id`.
* Use `first_or_create` to prevent duplicate TuringCensus creates.