### PR TITLE
Force rails form to display names correctly

### DIFF
--- a/app/views/admin/cohorts/show.html.erb
+++ b/app/views/admin/cohorts/show.html.erb
@@ -5,7 +5,7 @@
   <% @cohort.users.each do |student| %>
     <div class='checkbox-container'>
       <%= f.check_box student.full_name, id: "student-#{student.id}", name: "students[#{student.id}]" %>
-      <%= f.label student.full_name, for: "student-#{student.id}", class: "checkbox-label" %><br />
+      <%= f.label student.full_name, "#{student.full_name}", for: "student-#{student.id}", class: "checkbox-label" %><br />
     </div>
   <% end %>
 


### PR DESCRIPTION
* Didn't realize that rails tries to change labels to only capitalize the first letter.